### PR TITLE
fix: the py32io_gpio_direction_input() function acce... in py32ioexp.c

### DIFF
--- a/modules/py32ioexp-1.0/py32ioexp.c
+++ b/modules/py32ioexp-1.0/py32ioexp.c
@@ -372,6 +372,8 @@ static void py32io_gpio_set(struct gpio_chip *chip, unsigned offset, int value)
 
 static int py32io_gpio_direction_input(struct gpio_chip *chip, unsigned offset)
 {
+    if (offset >= chip->ngpio)
+        return -EINVAL;
     return py32io_gpio_set_direction(chip, offset, GPIO_LINE_DIRECTION_IN);
 }
 


### PR DESCRIPTION
## Summary
Fix high severity security issue in `modules/py32ioexp-1.0/py32ioexp.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-006 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-006` |
| **File** | `modules/py32ioexp-1.0/py32ioexp.c:373` |

**Description**: The py32io_gpio_direction_input() function accepts an unsigned offset parameter representing a GPIO pin number. If this offset is not validated against chip->ngpio before being used to index into internal arrays or I2C register maps, an out-of-bounds read or write can occur. A local user with access to the GPIO character device (/dev/gpiochipN) or sysfs GPIO interface can supply an out-of-range offset value to trigger this condition.

## Changes
- `modules/py32ioexp-1.0/py32ioexp.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
