### PR TITLE
fix(cardputerzero): gate speaker amplifier through DAPM

### DIFF
--- a/modules/CardputerZero/cardputerzero-audio.c
+++ b/modules/CardputerZero/cardputerzero-audio.c
@@ -542,6 +542,8 @@ static int cardputerzero_probe(struct platform_device *pdev)
 	card->dev = dev;
 	card->probe = cardputerzero_soc_probe;
 	card->driver_name = "cardputerzero-audio";
+	card->fully_routed = of_property_read_bool(dev->of_node,
+						   PREFIX "fully-routed");
 
 	ret = cardputerzero_parse_hp_mute_pins(cz, dev);
 	if (ret)

--- a/modules/CardputerZero/cardputerzero-v5-overlay.dts
+++ b/modules/CardputerZero/cardputerzero-v5-overlay.dts
@@ -334,6 +334,7 @@
 
             spk_mute_switch: spk-mute-switch {
                 compatible = "simple-audio-amplifier";
+                m5stack,mono;
 
                 enable-gpios = <&gpio 24 0>;
 
@@ -379,6 +380,7 @@
                 pinctrl-0 = <&sound_phones_pins>;
                 compatible = "m5stack,cardputerzero-audio";
                 simple-audio-card,name = "ES8389-Audio";
+                simple-audio-card,fully-routed;
                 status = "okay";
 
                 simple-audio-card,hp-det-gpios = <&gpio 17 0>;
@@ -409,8 +411,8 @@
                     "INPUT1", "Mic Jack",
                     "INPUT2", "Mic Jack",
 
-                    "Speaker Switch INL", "HPOL",
-                    "Speaker", "Speaker Switch OUTL";
+                    "Speaker Switch DRV", "HPOL",
+                    "Speaker", "Speaker Switch DRV";
                 simple-audio-card,dai-link {
                     format = "i2s";
                     bitclock-master = <&dailink0_master>;

--- a/modules/es8389-1.0/simple-amplifier.c
+++ b/modules/es8389-1.0/simple-amplifier.c
@@ -6,6 +6,7 @@
 
 #include <linux/gpio/consumer.h>
 #include <linux/module.h>
+#include <linux/property.h>
 #include <linux/regulator/consumer.h>
 #include <sound/soc.h>
 
@@ -65,9 +66,28 @@ static const struct snd_soc_component_driver simple_amp_component_driver = {
 	.num_dapm_routes	= ARRAY_SIZE(simple_amp_dapm_routes),
 };
 
+/* Model the mono amplifier as a stream-gated stage, not as DAPM endpoints. */
+static const struct snd_soc_dapm_widget simple_amp_mono_dapm_widgets[] = {
+	SND_SOC_DAPM_OUT_DRV_E("DRV", SND_SOC_NOPM, 0, 0, NULL, 0, drv_event,
+			       (SND_SOC_DAPM_POST_PMU | SND_SOC_DAPM_PRE_PMD)),
+	SND_SOC_DAPM_REGULATOR_SUPPLY("VCC", 20, 0),
+};
+
+static const struct snd_soc_dapm_route simple_amp_mono_dapm_routes[] = {
+	{ "DRV", NULL, "VCC" },
+};
+
+static const struct snd_soc_component_driver simple_amp_mono_component_driver = {
+	.dapm_widgets		= simple_amp_mono_dapm_widgets,
+	.num_dapm_widgets	= ARRAY_SIZE(simple_amp_mono_dapm_widgets),
+	.dapm_routes		= simple_amp_mono_dapm_routes,
+	.num_dapm_routes	= ARRAY_SIZE(simple_amp_mono_dapm_routes),
+};
+
 static int simple_amp_probe(struct platform_device *pdev)
 {
 	struct device *dev = &pdev->dev;
+	const struct snd_soc_component_driver *component_driver;
 	struct simple_amp *priv;
 
 	priv = devm_kzalloc(dev, sizeof(*priv), GFP_KERNEL);
@@ -81,8 +101,11 @@ static int simple_amp_probe(struct platform_device *pdev)
 		return dev_err_probe(dev, PTR_ERR(priv->gpiod_enable),
 				     "Failed to get 'enable' gpio");
 
+	component_driver = device_property_read_bool(dev, "m5stack,mono") ?
+		&simple_amp_mono_component_driver : &simple_amp_component_driver;
+
 	return devm_snd_soc_register_component(dev,
-					       &simple_amp_component_driver,
+					       component_driver,
 					       NULL, 0);
 }
 


### PR DESCRIPTION
Route the CardputerZero mono speaker explicitly, mark the simple-audio-card as fully routed, and let the ASoC DAPM path control AW8737A enable through the amplifier component.\n\nValidated with matching Raspberry Pi kernel modules/DTBO on CardputerZero hardware and included in the verified local image build.