### PR TITLE
fix(cardputerzero): persist ExtPort LED permissions

### DIFF
--- a/modules/CardputerZero/60-cardputerzero-leds.rules
+++ b/modules/CardputerZero/60-cardputerzero-leds.rules
@@ -1,0 +1,5 @@
+# LED class attributes are created after tmpfiles runs; apply permissions on add.
+ACTION=="add", SUBSYSTEM=="leds", KERNEL=="grove_fun", RUN+="/bin/chgrp gpio $sys$devpath/brightness", RUN+="/bin/chmod g+w $sys$devpath/brightness"
+ACTION=="add", SUBSYSTEM=="leds", KERNEL=="ext_usb_gpio_fun", RUN+="/bin/chgrp gpio $sys$devpath/brightness", RUN+="/bin/chmod g+w $sys$devpath/brightness"
+ACTION=="add", SUBSYSTEM=="leds", KERNEL=="ext_5v_out", RUN+="/bin/chgrp gpio $sys$devpath/brightness", RUN+="/bin/chmod g+w $sys$devpath/brightness"
+ACTION=="add", SUBSYSTEM=="leds", KERNEL=="grove_5v_out", RUN+="/bin/chgrp gpio $sys$devpath/brightness", RUN+="/bin/chmod g+w $sys$devpath/brightness"

--- a/modules/CardputerZero/Makefile
+++ b/modules/CardputerZero/Makefile
@@ -43,7 +43,9 @@ install_ko: $(Target_dtbo)
 
 install_led_permissions:
 	mkdir -p $(ROOTFSPATH)/usr/lib/tmpfiles.d/
+	mkdir -p $(ROOTFSPATH)/usr/lib/udev/rules.d/
 	install -m 0644 cardputerzero-leds.conf $(ROOTFSPATH)/usr/lib/tmpfiles.d/cardputerzero-leds.conf
+	install -m 0644 60-cardputerzero-leds.rules $(ROOTFSPATH)/usr/lib/udev/rules.d/60-cardputerzero-leds.rules
 
 clean:
 	$(MAKE) -C $(KERNELDIR) M=$(PWD) clean

--- a/modules/CardputerZero/cardputerzero-leds.conf
+++ b/modules/CardputerZero/cardputerzero-leds.conf
@@ -1,5 +1,5 @@
 # Allow unprivileged users to control CardputerZero GPIO LEDs.
-z /sys/class/leds/grove_fun/brightness        0666 - - -
-z /sys/class/leds/ext_usb_gpio_fun/brightness 0666 - - -
-z /sys/class/leds/ext_5v_out/brightness       0666 - - -
-z /sys/class/leds/grove_5v_out/brightness     0666 - - -
+z /sys/class/leds/grove_fun/brightness        0664 root gpio -
+z /sys/class/leds/ext_usb_gpio_fun/brightness 0664 root gpio -
+z /sys/class/leds/ext_5v_out/brightness       0664 root gpio -
+z /sys/class/leds/grove_5v_out/brightness     0664 root gpio -


### PR DESCRIPTION
Install tmpfiles and udev rules so the ExtPort LED class controls become writable whenever the devices are added and remain usable after cold boot. This keeps the upstream DAPM audio implementation unchanged.